### PR TITLE
Supports a block parameter on `err_if!` and `err_unless!` to be passed as part of a Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Of course, you can also use `.err_unless!`, `.err_if!`, and `.ok_if!` outside
 of the `Keka.run` block.
 
 ### Passing a block
-You can also pass a block to be executed if the result short circuits the execution. This block will only run if there is no `msg` provided.
+You can also pass a block to be executed if the result short circuits the execution. This is very useful for when you want to return a more complex `msg` than a String. For example, if you want to return an error class that validates certain properties upon initialization, then you will want to create the instance of error class in the block.
+
+NOTE: This block will only run if there is no `msg` provided.
 
 ```
 Keka.err_if!(true)         { raise Error } # Raises error

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ class Order
     Keka.run do
       # returns an err keka with provided msg if !refundable?
       Keka.err_unless!(refundable?, 'Payment is no longer refundable.')
-      # returns an err keka with provided msg if !refund!
-      Keka.err_unless!(payment.refund, 'Refund failed. Please try again')
+      # returns an err keka with value from provided block if refund does not exist
+      Keka.err_unless!(payment.refund) { CustomErrorClass.new(message: 'Already been refunded') }
       # execute statements if nothing 'return' from above
       do_something_else
       # if cancel_delivery
@@ -42,6 +42,13 @@ class Order
   end
 end
 
+class CustomErrorClass
+  def initialize(message:)
+    @message = message
+    Airbrake.notify('Received refund request for already refunded method')
+  end
+end
+
 class SomeController
   def some_action
     keka = @order.refund
@@ -56,6 +63,16 @@ end
 
 Of course, you can also use `.err_unless!`, `.err_if!`, and `.ok_if!` outside
 of the `Keka.run` block.
+
+### Passing a block
+You can also pass a block to be executed if the result short circuits the execution. This block will only run if there is no `msg` provided.
+
+```
+Keka.err_if!(true)         { raise Error } # Raises error
+Keka.err_if!(false)        { raise Error } # Does not raises error
+Keka.err_if!(true, 'msg')  { raise Error } # Does not raises error
+Keka.err_if!(false, 'msg') { raise Error } # Does not raises error
+```
 
 ### Abort Unconditionally
 

--- a/lib/keka/result.rb
+++ b/lib/keka/result.rb
@@ -9,14 +9,13 @@ module Keka
       is_success
     end
 
-    def msg=(msg_or_errors, &block)
+    def msg=(msg_or_errors)
       @msg_or_errors = msg_or_errors
     end
 
     def msg
       return @msg_or_errors if @msg_or_errors.is_a?(String)
       return @msg_or_errors.full_messages.join(', ') if active_model_error?
-      return yield @msg_or_errors if block_given? && is_success
 
       @msg_or_errors
     end
@@ -25,7 +24,6 @@ module Keka
       return {} if ok?
       return {base: [@msg_or_errors]} if @msg_or_errors.is_a?(String)
       return @msg_or_errors.messages if active_model_error?
-      return yield @msg_or_errors if block_given? && is_success
 
       {}
     end

--- a/lib/keka/result.rb
+++ b/lib/keka/result.rb
@@ -9,13 +9,14 @@ module Keka
       is_success
     end
 
-    def msg=(msg_or_errors)
+    def msg=(msg_or_errors, &block)
       @msg_or_errors = msg_or_errors
     end
 
     def msg
       return @msg_or_errors if @msg_or_errors.is_a?(String)
       return @msg_or_errors.full_messages.join(', ') if active_model_error?
+      return yield @msg_or_errors if block_given? && is_success
 
       @msg_or_errors
     end
@@ -24,6 +25,7 @@ module Keka
       return {} if ok?
       return {base: [@msg_or_errors]} if @msg_or_errors.is_a?(String)
       return @msg_or_errors.messages if active_model_error?
+      return yield @msg_or_errors if block_given? && is_success
 
       {}
     end

--- a/spec/keka_spec.rb
+++ b/spec/keka_spec.rb
@@ -57,12 +57,19 @@ RSpec.describe Keka do
 
   describe '.err_if!' do
     context 'when evaluating result object,' do
-      context 'when result is ok,' do
+      context 'when result is true,' do
         it 'halts' do
           result = described_class::Result.new(true, nil)
           expect{ described_class.err_if!(result) }.to raise_error do |error|
             expect(error.result).not_to be_ok
             expect(error.result.msg).to be_nil
+          end
+        end
+
+        context 'no error message' do
+          it 'accepts and runs a block' do
+            result = described_class::Result.new(true , nil)
+            expect{ described_class.err_if!(result) { raise 'foobar' } }.to raise_error('foobar')
           end
         end
 
@@ -82,12 +89,24 @@ RSpec.describe Keka do
               expect(error.result.msg).to be_nil
             end
           end
+
+          it 'ignores block if a message is provided' do
+            result = described_class::Result.new(true , nil)
+            expect{ described_class.err_if!(result, 'msg') { raise 'foobar' } }.not_to raise_error('foobar')
+          end
         end
       end
 
-      it 'does not halt when err' do
-        result = described_class::Result.new(false, nil)
-        expect{ described_class.err_if!(result) }.not_to raise_error
+      context 'when result is false,' do
+        it 'does not halt' do
+          result = described_class::Result.new(false, nil)
+          expect{ described_class.err_if!(result) }.not_to raise_error
+        end
+
+        it 'accepts but does not run a block' do
+          result = described_class::Result.new(false , nil)
+          expect{ described_class.err_if!(result) { raise 'foobar' } }.not_to raise_error('foobar')
+        end
       end
     end
 
@@ -122,9 +141,16 @@ RSpec.describe Keka do
 
   describe '.err_unless!' do
     context 'when evaluating result object,' do
-      it 'does not halt when result is ok' do
-        result = described_class::Result.new(true, nil)
-        expect{ described_class.err_unless!(result) }.not_to raise_error
+      context 'when result is ok,' do
+        it 'does not halt' do
+          result = described_class::Result.new(true, nil)
+          expect{ described_class.err_unless!(result) }.not_to raise_error
+        end
+
+        it 'accepts but does not run a block' do
+          result = described_class::Result.new(true , nil)
+          expect{ described_class.err_unless!(result) { raise 'foobar' } }.not_to raise_error('foobar')
+        end
       end
 
       context 'when result is err' do
@@ -133,6 +159,13 @@ RSpec.describe Keka do
           expect{ described_class.err_unless!(result) }.to raise_error do |error|
             expect(error.result).to eq result
             expect(error.result.msg).to be_nil
+          end
+        end
+
+        context 'no error message' do
+          it 'accepts and runs a block' do
+            result = described_class::Result.new(false , nil)
+            expect{ described_class.err_unless!(result) { raise 'foobar' } }.to raise_error('foobar')
           end
         end
 
@@ -151,6 +184,11 @@ RSpec.describe Keka do
               expect(error.result).to eq result
               expect(result.msg).to eq 'bar'
             end
+          end
+
+          it 'ignores block if a message is provided' do
+            result = described_class::Result.new(false , nil)
+            expect{ described_class.err_unless!(result, 'msg') { raise 'foobar' } }.not_to raise_error('foobar')
           end
         end
       end


### PR DESCRIPTION
Caveats
- Does not yield to the block if there is a message provided
- Does not implement block support for `ok` results